### PR TITLE
feat: delete application confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,4 @@ coding!
 - Pooja Balachandran: [GitHub] https://github.com/PCoderHub / [LinkedIn] https://www.linkedin.com/in/poojapbalachandran/
 - Eduard: [GitHub] https://github.com/EduardDE7
 - Shivani Bhardwaj: [GitHub](https://github.com/shivanibhardwaj0911) / [LinkedIn](https://www.linkedin.com/in/shivanibdwj)
-
-- Teammate name #n: [GitHub](https://github.com/ghaccountname) / [LinkedIn](https://linkedin.com/in/liaccountname)
+- Anderson Osayerie: [GitHub](https://github.com/andemosa) / [LinkedIn](https://www.linkedin.com/in/anderson-osayerie/)

--- a/react-orbit/src/components/applications/ApplicationActions.tsx
+++ b/react-orbit/src/components/applications/ApplicationActions.tsx
@@ -1,4 +1,5 @@
 import { MoreVertical, Pencil, Trash2 } from "lucide-react";
+
 import { Button } from "../ui/button";
 import {
   DropdownMenu,
@@ -6,44 +7,49 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
+
 import { Application } from "@/utils/localStorage";
 
 function ApplicationActions({
   index,
   application,
   onEdit,
+  onDelete,
 }: {
   index: number;
   application: Application;
   onEdit: (application: Application, index: number) => void;
+  onDelete: (index: number) => void;
 }) {
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon">
-          <MoreVertical className="text-gray-400" />
-        </Button>
-      </DropdownMenuTrigger>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon">
+            <MoreVertical className="text-gray-400" />
+          </Button>
+        </DropdownMenuTrigger>
 
-      <DropdownMenuContent
-        align="end"
-        className="border-gray-200 shadow-lg rounded-lg"
-      >
-        <DropdownMenuItem
-          className="p-4"
-          onClick={() => onEdit(application, index)}
+        <DropdownMenuContent
+          align="end"
+          className="border-gray-200 shadow-lg rounded-lg"
         >
-          <Pencil className="mr-2 text-gray-400" />
-          <span className="font-semibold text-sm">Edit Application</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem className="p-4">
-          <Trash2 className="mr-2 text-red-500" />
-          <span className="font-semibold text-sm text-red-500">
-            Delete Application
-          </span>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <DropdownMenuItem
+            className="p-4"
+            onClick={() => onEdit(application, index)}
+          >
+            <Pencil className="mr-2 text-gray-400" />
+            <span className="font-semibold text-sm">Edit Application</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem className="p-4" onClick={() => onDelete(index)}>
+            <Trash2 className="mr-2 text-red-500" />
+            <span className="font-semibold text-sm text-red-500">
+              Delete Application
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
   );
 }
 

--- a/react-orbit/src/components/applications/ApplicationCard.tsx
+++ b/react-orbit/src/components/applications/ApplicationCard.tsx
@@ -8,10 +8,12 @@ function ApplicationCard({
   application,
   index,
   onEdit,
+  onDelete
 }: {
   application: Application;
   index: number;
   onEdit: (application: Application, index: number) => void;
+  onDelete: (index: number) => void;
 }) {
   const styles = getStatusStyles(application.Status);
 
@@ -47,6 +49,7 @@ function ApplicationCard({
             index={index}
             application={application}
             onEdit={onEdit}
+            onDelete={onDelete}
           />
         </div>
       </div>

--- a/react-orbit/src/components/applications/ApplicationList.tsx
+++ b/react-orbit/src/components/applications/ApplicationList.tsx
@@ -5,9 +5,11 @@ import ApplicationCard from "./ApplicationCard";
 function ApplicationList({
   applications,
   onEdit,
+  onDelete
 }: {
   applications: Application[];
   onEdit: (application: Application, index: number) => void;
+  onDelete: (index: number) => void
 }) {
   if (applications.length === 0) {
     return <EmptyState />;
@@ -21,6 +23,7 @@ function ApplicationList({
           application={application}
           index={index}
           onEdit={onEdit}
+          onDelete={onDelete}
         />
       ))}
     </div>

--- a/react-orbit/src/components/applications/ConfirmDeleteModal.tsx
+++ b/react-orbit/src/components/applications/ConfirmDeleteModal.tsx
@@ -17,16 +17,16 @@ export default function DeleteConfirmationModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md text-center p-6 rounded-3xl">
-        <div className="flex justify-center mb-4">
+      <DialogContent className="max-w-sm text-center p-6 rounded-3xl">
+        <div className="flex justify-center mb-2">
           <div className="bg-red-100 p-4 rounded-full">
             <Trash2 className="text-red-600 w-6 h-6" />
           </div>
         </div>
 
-        <h2 className="text-lg font-bold mb-2">Confirm Deletion</h2>
+        <h2 className="text-lg font-bold">Confirm Deletion</h2>
 
-        <p className="text-sm text-gray-500 mb-6 max-w-4/5 mx-auto">
+        <p className="text-sm text-gray-500 mb-3">
           Are you sure you want to delete this? This action cannot be undone and
           will remove all tracking history for this application.
         </p>
@@ -34,7 +34,7 @@ export default function DeleteConfirmationModal({
         <div className="flex justify-center gap-3">
           <Button
             variant="outline"
-            className="w-full rounded-xl"
+            className="w-full rounded-xl py-5 bg-blue-200 text-gray-700 font-semibold"
             onClick={() => onOpenChange(false)}
           >
             Cancel
@@ -42,7 +42,7 @@ export default function DeleteConfirmationModal({
 
           <Button
             variant="destructive"
-            className="w-full rounded-xl"
+            className="w-full rounded-xl py-5 font-semibold"
             onClick={onConfirm}
           >
             Delete

--- a/react-orbit/src/components/applications/ConfirmDeleteModal.tsx
+++ b/react-orbit/src/components/applications/ConfirmDeleteModal.tsx
@@ -1,0 +1,54 @@
+import { Trash2 } from "lucide-react";
+
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+type DeleteConfirmationModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void
+};
+
+export default function DeleteConfirmationModal({
+  open,
+  onOpenChange,
+  onConfirm
+}: DeleteConfirmationModalProps) {
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md text-center p-6 rounded-3xl">
+        <div className="flex justify-center mb-4">
+          <div className="bg-red-100 p-4 rounded-full">
+            <Trash2 className="text-red-600 w-6 h-6" />
+          </div>
+        </div>
+
+        <h2 className="text-lg font-bold mb-2">Confirm Deletion</h2>
+
+        <p className="text-sm text-gray-500 mb-6 max-w-4/5 mx-auto">
+          Are you sure you want to delete this? This action cannot be undone and
+          will remove all tracking history for this application.
+        </p>
+
+        <div className="flex justify-center gap-3">
+          <Button
+            variant="outline"
+            className="w-full rounded-xl"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+
+          <Button
+            variant="destructive"
+            className="w-full rounded-xl"
+            onClick={onConfirm}
+          >
+            Delete
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/react-orbit/src/hooks/useApplications.ts
+++ b/react-orbit/src/hooks/useApplications.ts
@@ -25,10 +25,18 @@ export function useApplications() {
     }
   };
 
+  const removeApplication = (index: number) => {
+    const updatedApplications = LocalStorage.removeApplication(index);
+    if (updatedApplications) {
+      setApplications(updatedApplications);
+    }
+  };
+
   return {
     applications,
     setApplications,
     addApplication,
     updateApplication,
+    removeApplication,
   };
 }

--- a/react-orbit/src/pages/ApplicationsPage.tsx
+++ b/react-orbit/src/pages/ApplicationsPage.tsx
@@ -2,28 +2,46 @@ import ApplicationList from "@/components/applications/ApplicationList";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import NewApplicationModal from "@/components/NewApplicationModal";
+import DeleteConfirmationModal from "@/components/applications/ConfirmDeleteModal";
+
 import { useApplications } from "@/hooks/useApplications";
 import { Application } from "@/utils/localStorage";
 
 export function ApplicationsPage() {
   const [open, setOpen] = useState(false);
-  const { applications, addApplication, updateApplication } = useApplications();
+  const [removeOpen, setRemoveOpen] = useState(false);
+
+  const { applications, addApplication, updateApplication, removeApplication } =
+    useApplications();
   const [editApplication, setEditApplication] = useState<Application | null>(
     null,
   );
 
   // NOTE: index for update application - need to switch to proper id when backend implementation to avoid wrong renders
   const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
 
   const handleCreate = () => {
     setEditApplication(null);
     setEditIndex(null);
     setOpen(true);
   };
+  
   const handleEdit = (app: Application, index: number) => {
     setEditApplication(app);
     setEditIndex(index);
     setOpen(true);
+  };
+
+  const handleDelete = (index: number) => {
+    setDeleteIndex(index);
+    setRemoveOpen(true);
+  };
+
+  const handleRemoveConfirm = () => {
+    if (deleteIndex !== null) removeApplication(deleteIndex);
+    setDeleteIndex(null)
+    setRemoveOpen(false)
   };
 
   return (
@@ -58,7 +76,19 @@ export function ApplicationsPage() {
         />
       </div>
 
-      <ApplicationList applications={applications} onEdit={handleEdit} />
+      <ApplicationList
+        applications={applications}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+      />
+
+      {removeOpen ? (
+        <DeleteConfirmationModal
+          open={removeOpen}
+          onOpenChange={setRemoveOpen}
+          onConfirm={handleRemoveConfirm}
+        />
+      ) : null}
     </section>
   );
 }

--- a/react-orbit/src/pages/ApplicationsPage.tsx
+++ b/react-orbit/src/pages/ApplicationsPage.tsx
@@ -1,6 +1,8 @@
-import ApplicationList from "@/components/applications/ApplicationList";
 import { useState } from "react";
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
+import ApplicationList from "@/components/applications/ApplicationList";
 import NewApplicationModal from "@/components/NewApplicationModal";
 import DeleteConfirmationModal from "@/components/applications/ConfirmDeleteModal";
 
@@ -26,7 +28,7 @@ export function ApplicationsPage() {
     setEditIndex(null);
     setOpen(true);
   };
-  
+
   const handleEdit = (app: Application, index: number) => {
     setEditApplication(app);
     setEditIndex(index);
@@ -40,8 +42,14 @@ export function ApplicationsPage() {
 
   const handleRemoveConfirm = () => {
     if (deleteIndex !== null) removeApplication(deleteIndex);
-    setDeleteIndex(null)
-    setRemoveOpen(false)
+    setDeleteIndex(null);
+    setRemoveOpen(false);
+    toast.success("Application removed!");
+  };
+
+  const handleRemoveOpenChange = (open: boolean) => {
+    setRemoveOpen(open);
+    if (!open) setDeleteIndex(null);
   };
 
   return (
@@ -82,13 +90,11 @@ export function ApplicationsPage() {
         onDelete={handleDelete}
       />
 
-      {removeOpen ? (
-        <DeleteConfirmationModal
-          open={removeOpen}
-          onOpenChange={setRemoveOpen}
-          onConfirm={handleRemoveConfirm}
-        />
-      ) : null}
+      <DeleteConfirmationModal
+        open={removeOpen}
+        onOpenChange={handleRemoveOpenChange}
+        onConfirm={handleRemoveConfirm}
+      />
     </section>
   );
 }

--- a/react-orbit/src/pages/DashboardPage.tsx
+++ b/react-orbit/src/pages/DashboardPage.tsx
@@ -2,17 +2,23 @@ import ApplicationList from "@/components/applications/ApplicationList";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import NewApplicationModal from "@/components/NewApplicationModal";
+import DeleteConfirmationModal from "@/components/applications/ConfirmDeleteModal";
+
 import { Application } from "@/utils/localStorage";
 import { useApplications } from "@/hooks/useApplications";
 
 export function DashboardPage() {
   const [open, setOpen] = useState(false);
+  const [removeOpen, setRemoveOpen] = useState(false);
+
   const [editApplication, setEditApplication] = useState<Application | null>(
     null,
   );
   const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
 
-  const { applications, addApplication, updateApplication } = useApplications();
+  const { applications, addApplication, updateApplication, removeApplication } =
+    useApplications();
 
   const handleCreate = () => {
     setEditApplication(null);
@@ -24,6 +30,17 @@ export function DashboardPage() {
     setEditApplication(app);
     setEditIndex(index);
     setOpen(true);
+  };
+
+  const handleDelete = (index: number) => {
+    setDeleteIndex(index);
+    setRemoveOpen(true);
+  };
+
+  const handleRemoveConfirm = () => {
+    if (deleteIndex !== null) removeApplication(deleteIndex);
+    setDeleteIndex(null);
+    setRemoveOpen(false);
   };
 
   return (
@@ -57,7 +74,19 @@ export function DashboardPage() {
       />
 
       <h2 className="text-2xl font-bold mt-8 mb-4">Applications</h2>
-      <ApplicationList applications={applications} onEdit={handleEdit} />
+      <ApplicationList
+        applications={applications}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+      />
+
+      {removeOpen ? (
+        <DeleteConfirmationModal
+          open={removeOpen}
+          onOpenChange={setRemoveOpen}
+          onConfirm={handleRemoveConfirm}
+        />
+      ) : null}
     </>
   );
 }

--- a/react-orbit/src/pages/DashboardPage.tsx
+++ b/react-orbit/src/pages/DashboardPage.tsx
@@ -1,6 +1,8 @@
-import ApplicationList from "@/components/applications/ApplicationList";
 import { useState } from "react";
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
+import ApplicationList from "@/components/applications/ApplicationList";
 import NewApplicationModal from "@/components/NewApplicationModal";
 import DeleteConfirmationModal from "@/components/applications/ConfirmDeleteModal";
 
@@ -41,6 +43,12 @@ export function DashboardPage() {
     if (deleteIndex !== null) removeApplication(deleteIndex);
     setDeleteIndex(null);
     setRemoveOpen(false);
+    toast.success("Application removed!");
+  };
+
+  const handleRemoveOpenChange = (open: boolean) => {
+    setRemoveOpen(open);
+    if (!open) setDeleteIndex(null);
   };
 
   return (
@@ -80,13 +88,11 @@ export function DashboardPage() {
         onDelete={handleDelete}
       />
 
-      {removeOpen ? (
-        <DeleteConfirmationModal
-          open={removeOpen}
-          onOpenChange={setRemoveOpen}
-          onConfirm={handleRemoveConfirm}
-        />
-      ) : null}
+      <DeleteConfirmationModal
+        open={removeOpen}
+        onOpenChange={handleRemoveOpenChange}
+        onConfirm={handleRemoveConfirm}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Implements a confirmation modal before permanently deleting a job application, preventing accidental deletions. Closes #34.

---

## Changes

**New component — `ConfirmDeleteModal.tsx`**
A reusable `DeleteConfirmationModal` dialog built on the existing `Dialog` primitive. Displays a Trash2 icon, a warning message, and Cancel / Delete actions. The modal is intentionally generic so it can be reused across other delete flows.

**`useApplications.ts`**
Added a `removeApplication` hook method that calls `LocalStorage.removeApplication(index)` and syncs the result back into component state.

**`ApplicationActions.tsx`**
Added an `onDelete` prop. The "Delete Application" dropdown item now calls `onDelete(index)` instead of acting immediately, delegating the confirmation responsibility to the parent.

**`ApplicationCard.tsx` / `ApplicationList.tsx`**
Threaded the `onDelete` prop down the component tree from page → list → card → actions.

**`ApplicationsPage.tsx` / `DashboardPage.tsx`**
Both pages now manage `removeOpen` and `deleteIndex` state. `handleDelete` sets the target index and opens the modal; `handleRemoveConfirm` calls `removeApplication` and resets state on confirmation.

---

## Behaviour

1. User clicks the ⋮ menu on an application card and selects **Delete Application**.
2. A modal appears asking: *"Are you sure you want to delete this? This action cannot be undone and will remove all tracking history for this application."*
3. **Cancel** — closes the modal, no changes made.
4. **Delete** — removes the application from state and localStorage, then closes the modal.

---

## Notes

- Index-based deletion is a known limitation acknowledged in existing code comments. Should be refactored to ID-based lookups once backend integration lands.
- The modal is conditionally rendered (`{removeOpen ? ... : null}`) rather than always mounted.